### PR TITLE
Add smart file synchronization with --update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ When installed, this project adds **two new tasks** to your muOS Pixie device's 
 1. **📤 Cloud Upload Saves** - Uploads your save files and screenshots to cloud storage
 2. **📥 Cloud Download Saves** - Downloads your save files and screenshots from cloud storage
 
+### 🔄 Smart Synchronization Behavior
+
+Both upload and download operations use **intelligent file comparison** to protect your data:
+
+- **📥 Download**: Only downloads files from the cloud that are **newer** than your local versions
+- **📤 Upload**: Only uploads local files that are **newer** than the cloud versions
+- **🛡️ Data Protection**: Prevents accidental overwriting of newer save files with older ones
+- **⚡ Efficiency**: Skips unnecessary transfers, saving time and bandwidth
+
+**Example Scenarios:**
+- Playing on multiple devices? Each device only syncs files that are actually newer
+- Forgot to download before playing? Your recent local progress won't be lost when uploading
+- Forgot to upload before switching devices? Your cloud progress won't be overwritten
+
+> **💡 Pro Tip:** This bidirectional protection means you can safely run upload/download operations without worrying about losing recent progress from either location!
+
 > **🎨 Icon Note:** The included PNG files in `copy_to_tools_directory/` are provided for users who wish to embed custom icons into their Theme installation files. The setup guide will automatically install these icons when you run the tasks for the first time.
 
 > **📁 Repository Structure:** This repository is organized with separate directories:

--- a/copy_to_tasks_directory/Cloud_Download_Saves.sh
+++ b/copy_to_tasks_directory/Cloud_Download_Saves.sh
@@ -124,7 +124,7 @@ echo ""
 
 ##################################################################################
 ## Download operations
-## 
+##
 ## Using --update flag to only download files that are newer on the cloud
 ## than the local versions. This prevents overwriting newer local saves
 ## with older cloud versions.

--- a/copy_to_tasks_directory/Cloud_Download_Saves.sh
+++ b/copy_to_tasks_directory/Cloud_Download_Saves.sh
@@ -124,21 +124,26 @@ echo ""
 
 ##################################################################################
 ## Download operations
+## 
+## Using --update flag to only download files that are newer on the cloud
+## than the local versions. This prevents overwriting newer local saves
+## with older cloud versions.
 ##################################################################################
 
 ## TODO: fix how to display the info panel in muOS
 # Display an info panel
 #LD_PRELOAD=/run/muos/storage/lib/libpadsp.so /run/muos/storage/bin/infoPanel -t "Downloading Saves" -m "Your saves are being downloaded from Dropbox!" --auto &
 
-# Synchronize saves
-echo "📥 Downloading save files..."
-${RCLONE_BINARY} copy -P -L --no-check-certificate "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" --config="${RCLONE_CONFIG}"
+# Synchronize saves (only update files that are newer on cloud)
+echo "📥 Downloading save files (only newer files)..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" --config="${RCLONE_CONFIG}"
 
-# Synchronize screenshots
-echo "📸 Downloading screenshots..."
-${RCLONE_BINARY} copy -P -L --no-check-certificate "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" "${SCREENSHOT_DIR}/" --config="${RCLONE_CONFIG}"
+# Synchronize screenshots (only update files that are newer on cloud)
+echo "📸 Downloading screenshots (only newer files)..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" "${SCREENSHOT_DIR}/" --config="${RCLONE_CONFIG}"
 
 echo ""
 echo "✅ Download completed successfully!"
+echo "   Only files newer than local versions were updated"
 
 

--- a/copy_to_tasks_directory/Cloud_Upload_Saves.sh
+++ b/copy_to_tasks_directory/Cloud_Upload_Saves.sh
@@ -124,19 +124,24 @@ echo ""
 
 ##################################################################################
 ## Upload operations
+## 
+## Using --update flag to only upload files that are newer locally
+## than the cloud versions. This prevents overwriting newer cloud saves
+## with older local versions.
 ##################################################################################
 
 ## TODO: fix how to display the info panel in muOS
 # Display an info panel 
 #LD_PRELOAD=/mnt/mmc/MUOS/lib/libpadsp.so /mnt/mmc/MUOS/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
 
-# Synchronize saves
-echo "📤 Uploading save files..."
-${RCLONE_BINARY} copy -P -L --no-check-certificate "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" --config="${RCLONE_CONFIG}"
+# Synchronize saves (only upload files that are newer locally)
+echo "📤 Uploading save files (only newer files)..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" --config="${RCLONE_CONFIG}"
 
-# Synchronize screenshots
-echo "📸 Uploading screenshots..."
-${RCLONE_BINARY} copy -P -L --no-check-certificate "${SCREENSHOT_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" --config="${RCLONE_CONFIG}"
+# Synchronize screenshots (only upload files that are newer locally)
+echo "📸 Uploading screenshots (only newer files)..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${SCREENSHOT_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" --config="${RCLONE_CONFIG}"
 
 echo ""
 echo "✅ Upload completed successfully!"
+echo "   Only files newer than cloud versions were uploaded"

--- a/copy_to_tasks_directory/Cloud_Upload_Saves.sh
+++ b/copy_to_tasks_directory/Cloud_Upload_Saves.sh
@@ -124,7 +124,7 @@ echo ""
 
 ##################################################################################
 ## Upload operations
-## 
+##
 ## Using --update flag to only upload files that are newer locally
 ## than the cloud versions. This prevents overwriting newer cloud saves
 ## with older local versions.


### PR DESCRIPTION
- Add --update flag to both upload and download scripts
- Only sync files that are newer than destination versions
- Prevents overwriting newer saves with older ones
- Protects data when switching between devices
- Updates README with smart synchronization behavior documentation
- Enhances safety for multi-device gaming scenarios