### PR TITLE
Update for MustardOS 2601.1 Funky Jacaranda

### DIFF
--- a/1-Setup-Rclone-Configuration.md
+++ b/1-Setup-Rclone-Configuration.md
@@ -90,7 +90,7 @@ Your rclone configuration is stored in a file named `rclone.conf`.
 
 > **🎯 Important for muOS Setup:** This `rclone.conf` file will be used in Step 2 to copy to your muOS handheld's root OS SD card. Make note of the file location as you'll need to transfer it to your handheld device.
 
-> **💡 Tip:** You can copy this file to other muOS devices (Goose) to replicate the configuration.
+> **💡 Tip:** You can copy this file to other muOS (MustardOS) devices to replicate the configuration.
 
 ## 📚 Additional Resources
 

--- a/2-Setup-muOS-Cloud-Sync.md
+++ b/2-Setup-muOS-Cloud-Sync.md
@@ -4,7 +4,7 @@
 
 ---
 
-This guide will help you set up cloud synchronization on your muOS device (Goose release) using the rclone configuration you created on your computer.
+This guide will help you set up cloud synchronization on your MustardOS 2601.1 (Funky Jacaranda) device using the rclone configuration you created on your computer.
 
 ## 📋 Prerequisites
 
@@ -14,6 +14,8 @@ This guide will help you set up cloud synchronization on your muOS device (Goose
 - ✅ Completed rclone configuration from [Step 1](./1-Setup-Rclone-Configuration.md)
 
 ## 📁 Step 1: Download the ARMv7 rclone Binary
+
+> **Note:** MustardOS 2601.1 (Funky Jacaranda) ships with rclone pre-installed at `/opt/muos/bin/rclone`. If your muOS version has rclone pre-installed, you can skip this step.
 
 1. On your desktop computer, open a web browser and navigate to the rclone downloads page:
    
@@ -35,7 +37,7 @@ This guide will help you set up cloud synchronization on your muOS device (Goose
 
 ## 📂 Step 3: Transfer Files to the SD Card
 
-1. Open the main OS SD card on your computer. It should have a directory named `MUOS` , on your device this typically at `/mnt/mmc/MUOS/`  
+1. Open the main OS SD card on your computer. It should have a directory named `MUOS`, on your device this is typically at your SD card's MUOS directory (paths are dynamically resolved by the scripts)  
 
 ### 📝 Important Note for qty=2 SD card users OS and a ROMs SD card: 
 the files being copied should go into SD slot #1 that has the MUOS operating system.
@@ -44,21 +46,21 @@ the files being copied should go into SD slot #1 that has the MUOS operating sys
    - **Windows/macOS:** Right-click in the MUOS folder → New Folder → Name it `tools`
    - **Linux:** Create the directory if it doesn't exist
 
-3. **Choose your installation path for muOS Goose:**
+3. **Choose your installation path for MustardOS:**
 
 > **Important:** The task directory `/opt/muos/share/task` is on the Linux system partition, not the SD card’s FAT partition. macOS/Windows can’t write to it directly. You must use **SSH/SCP** to copy task scripts and set permissions.
 
 ### 🔧 Required File Transfers:
 
-**For muOS Goose:**
+**For MustardOS (Funky Jacaranda):**
 | Source (from this repository) | Destination on SD Card |
 |-------------------------------|------------------------|
-| `rclone` armv7 32-bit linux binary (downloaded separately) | `MUOS/tools/rclone` |
+| `rclone` armv7 32-bit linux binary (downloaded separately) | `MUOS/tools/rclone` (or use pre-installed `/opt/muos/bin/rclone`) |
 | `rclone.conf` file (from your PC setup) | `MUOS/tools/rclone.conf` |
 | `copy_to_tools_directory/Cloud_Upload_Saves.png` | `MUOS/tools/Cloud_Upload_Saves.png` |
 | `copy_to_tools_directory/Cloud_Download_Saves.png` | `MUOS/tools/Cloud_Download_Saves.png` |
 
-**🦆 For muOS Goose users:**
+**🦆 For MustardOS users:**
 | Source (from this repository) | Destination on SD Card |
 |-------------------------------|------------------------|
 | `copy_to_tasks_directory/backup/cloud_upload_saves.sh` | `/opt/muos/share/task/cloud_upload_saves.sh` |
@@ -88,7 +90,7 @@ ssh root@YOUR_DEVICE_IP \
 > **📝 Important Notes:** 
 > - Copy your `rclone.conf` file that you configured with your cloud service from your PC (Step 1)
 > - The PNG icon files are optional but will provide custom icons for your tasks if your theme supports them
-> - For Goose, copy the scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/` on the device via SSH (this is on the muOS system partition, not the SD card FAT partition)
+> - For MustardOS, copy the scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/` on the device via SSH (this is on the muOS system partition, not the SD card FAT partition)
 > - All files from `copy_to_tools_directory/` go to `MUOS/tools/` on your SD card
 
 ## ⚙️ Step 4: Set Executable Permissions
@@ -102,9 +104,10 @@ If you're using a Unix-based system, ensure the scripts and rclone binary are ex
 3. Run the following commands:
 
 ```bash
+# If you installed rclone manually to tools/:
 chmod +x tools/rclone
 
-# Set permissions for Goose (via SSH):
+# Set permissions for MustardOS (via SSH):
 chmod +x /opt/muos/share/task/cloud_upload_saves.sh
 chmod +x /opt/muos/share/task/cloud_download_saves.sh
 ```
@@ -120,7 +123,7 @@ chmod +x /opt/muos/share/task/cloud_download_saves.sh
 2. **Insert** the SD card back into your Anbernic device
 3. **Power on** the device
 4. **Navigate** to the Tasks menu:
-   - **Goose**: Applications → Task Toolkit → Backup
+   - **MustardOS**: Applications → Task Toolkit
 5. You should see:
     - 📤 **Cloud Upload Saves**
     - 📥 **Cloud Download Saves**
@@ -132,9 +135,9 @@ chmod +x /opt/muos/share/task/cloud_download_saves.sh
 
 > **⏰ Time Sync Critical:** Enable internet time synchronization in muOS settings to ensure proper timestamps on save files. Incorrect timestamps can cause sync conflicts and file versioning issues
 
-> **🔗 Compatibility:** The tasks utilize symlinked paths (`/mnt/mmc/MUOS/`) for compatibility across different storage setups
+> **🔗 Compatibility:** The tasks use dynamic path resolution (`GET_VAR` and `${MUOS_STORE_DIR}`) for compatibility across different storage setups
 
-> **🎯 muOS Version Support:** This setup supports Goose release tasks under `/opt/muos/share/task`
+> **🎯 muOS Version Support:** This setup supports MustardOS 2601.1 (Funky Jacaranda) tasks under `/opt/muos/share/task` — tested and working on Anbernic RG40XX
 
 > **⚙️ Customization:** Customize the scripts as needed to match your specific directory structures or cloud service configurations
 
@@ -148,11 +151,11 @@ For more information on muOS and its features, visit:
 
 ## 🎯 Quick Setup Checklist
 
-- [ ] Downloaded ARMv7 rclone binary from rclone.org
-- [ ] Copied rclone binary to `MUOS/tools/rclone`
+- [ ] Downloaded ARMv7 rclone binary from rclone.org (or skip if MustardOS pre-installed)
+- [ ] Copied rclone binary to `MUOS/tools/rclone` (or use pre-installed `/opt/muos/bin/rclone`)
 - [ ] Copied your rclone.conf (from Step 1) to `MUOS/tools/rclone.conf`
 - [ ] Copied PNG files from `copy_to_tools_directory/` to `MUOS/tools/`
-- [ ] **For Goose**: Copied shell scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/`
+- [ ] Copied shell scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/`
 - [ ] Set executable permissions (Unix systems)
 - [ ] Tested cloud upload/download tasks
 

--- a/2-Setup-muOS-Cloud-Sync.md
+++ b/2-Setup-muOS-Cloud-Sync.md
@@ -13,21 +13,17 @@ This guide will help you set up cloud synchronization on your MustardOS 2601.1 (
 - ✅ Internet connection on your Anbernic device (if required by your cloud service)
 - ✅ Completed rclone configuration from [Step 1](./1-Setup-Rclone-Configuration.md)
 
-## 📁 Step 1: Download the ARMv7 rclone Binary
+## 📁 Step 1: rclone Binary
 
-> **Note:** MustardOS 2601.1 (Funky Jacaranda) ships with rclone pre-installed at `/opt/muos/bin/rclone`. If your muOS version has rclone pre-installed, you can skip this step.
+> **✅ rclone is pre-installed on MuOS 2025 and later** at `/opt/muos/bin/rclone`. No download needed — the scripts use this automatically.
 
-1. On your desktop computer, open a web browser and navigate to the rclone downloads page:
-   
-   🌐 **[https://rclone.org/downloads/](https://rclone.org/downloads/)**
+If you are on an older MuOS version without the pre-installed binary, you can manually place an ARM64 rclone binary at `MUOS/tools/rclone` on the SD card and the scripts will fall back to it:
 
-2. Scroll down to the **"Linux ARM - 32 Bit"** section
+1. Download the **Linux ARM - 64 Bit** binary from **[https://rclone.org/downloads/](https://rclone.org/downloads/)**
+2. Extract and copy the `rclone` executable to `MUOS/tools/rclone` on your SD card
+3. Set permissions via SSH: `chmod +x /path/to/MUOS/tools/rclone`
 
-3. Click on the link to download the latest ARMv7 binary
-   
-   Example: `rclone-v1.69.2-linux-arm-v7.zip`
-
-4. Once downloaded, extract the zip file to obtain the `rclone` executable
+> **⚠️ Architecture note:** These devices (TrimUI Brick, Anbernic RG40XX series) are 64-bit ARM (aarch64). Use the **ARM64** binary, not ARMv7.
 
 ## 💾 Step 2: Insert the OS SD Card (SD1)
 
@@ -153,8 +149,7 @@ For more information on muOS and its features, visit:
 
 ## 🎯 Quick Setup Checklist
 
-- [ ] Downloaded ARMv7 rclone binary from rclone.org (or skip if MustardOS pre-installed)
-- [ ] Copied rclone binary to `MUOS/tools/rclone` (or use pre-installed `/opt/muos/bin/rclone`)
+- [ ] Confirmed rclone is available (pre-installed at `/opt/muos/bin/rclone` on MuOS 2025+, or manually placed ARM64 binary at `MUOS/tools/rclone`)
 - [ ] Copied your rclone.conf (from Step 1) to `MUOS/tools/rclone.conf`
 - [ ] Copied PNG files from `copy_to_tools_directory/` to `MUOS/tools/`
 - [ ] Copied shell scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/Rclone_Tasks/` via SSH

--- a/2-Setup-muOS-Cloud-Sync.md
+++ b/2-Setup-muOS-Cloud-Sync.md
@@ -61,28 +61,30 @@ the files being copied should go into SD slot #1 that has the MUOS operating sys
 | `copy_to_tools_directory/Cloud_Download_Saves.png` | `MUOS/tools/Cloud_Download_Saves.png` |
 
 **🦆 For MustardOS users:**
-| Source (from this repository) | Destination on SD Card |
-|-------------------------------|------------------------|
-| `copy_to_tasks_directory/backup/cloud_upload_saves.sh` | `/opt/muos/share/task/cloud_upload_saves.sh` |
-| `copy_to_tasks_directory/backup/cloud_download_saves.sh` | `/opt/muos/share/task/cloud_download_saves.sh` |
+| Source (from this repository) | Destination on device (via SSH) |
+|-------------------------------|----------------------------------|
+| `copy_to_tasks_directory/backup/cloud_upload_saves.sh` | `/opt/muos/share/task/Rclone_Tasks/cloud_upload_saves.sh` |
+| `copy_to_tasks_directory/backup/cloud_download_saves.sh` | `/opt/muos/share/task/Rclone_Tasks/cloud_download_saves.sh` |
+
+> **☁️ Cloud folder auto-detection:** The scripts automatically detect your device's board name (e.g. `rg40xx-h`, `tui-brick`) and use it as the cloud folder — no manual configuration needed. Each device gets its own folder in your cloud storage.
 
 ### 🔐 Copy via SSH/SCP (required for /opt/muos/share/task)
 
-Example (replace host and folder as needed):
+Example (replace `YOUR_DEVICE_IP` with your device's IP address):
 
 ```bash
-# Create a folder (optional)
-ssh root@YOUR_DEVICE_IP 'mkdir -p "/opt/muos/share/task/Rclone Tasks"'
+# Create the Rclone_Tasks folder
+ssh root@YOUR_DEVICE_IP 'mkdir -p /opt/muos/share/task/Rclone_Tasks'
 
 # Copy scripts
 scp copy_to_tasks_directory/backup/cloud_upload_saves.sh \
    copy_to_tasks_directory/backup/cloud_download_saves.sh \
-   root@YOUR_DEVICE_IP:"/opt/muos/share/task/Rclone Tasks/"
+   root@YOUR_DEVICE_IP:/opt/muos/share/task/Rclone_Tasks/
 
 # Set executable permissions
 ssh root@YOUR_DEVICE_IP \
-   'chmod +x "/opt/muos/share/task/Rclone Tasks/cloud_upload_saves.sh" \
-   "/opt/muos/share/task/Rclone Tasks/cloud_download_saves.sh"'
+   'chmod +x /opt/muos/share/task/Rclone_Tasks/cloud_upload_saves.sh \
+   /opt/muos/share/task/Rclone_Tasks/cloud_download_saves.sh'
 ```
 
 > **🔐 SSH Login Note:** Most users connect as `root` and enter the default muOS password (or whatever you changed it to). If you use keys, add `-i ~/.ssh/your_key` to the commands.
@@ -108,13 +110,13 @@ If you're using a Unix-based system, ensure the scripts and rclone binary are ex
 chmod +x tools/rclone
 
 # Set permissions for MustardOS (via SSH):
-chmod +x /opt/muos/share/task/cloud_upload_saves.sh
-chmod +x /opt/muos/share/task/cloud_download_saves.sh
+chmod +x /opt/muos/share/task/Rclone_Tasks/cloud_upload_saves.sh
+chmod +x /opt/muos/share/task/Rclone_Tasks/cloud_download_saves.sh
 ```
 
-> **💡 Tip:** You can also copy the executable permissions for all shell scripts at once:
+> **💡 Tip:** You can also set permissions for all scripts in the folder at once:
 > ```bash
-> chmod +x /opt/muos/share/task/*.sh
+> chmod +x /opt/muos/share/task/Rclone_Tasks/*.sh
 > ```
 
 ## 🔄 Step 5: Reinsert the SD Card and Access Tasks
@@ -137,7 +139,7 @@ chmod +x /opt/muos/share/task/cloud_download_saves.sh
 
 > **🔗 Compatibility:** The tasks use dynamic path resolution (`GET_VAR` and `${MUOS_STORE_DIR}`) for compatibility across different storage setups
 
-> **🎯 muOS Version Support:** This setup supports MustardOS 2601.1 (Funky Jacaranda) tasks under `/opt/muos/share/task` — tested and working on Anbernic RG40XX
+> **🎯 muOS Version Support:** Tested on MustardOS Funky Jacaranda (2026) and Loose Goose (2025) on Anbernic and TrimUI devices. Task scripts go in `/opt/muos/share/task/Rclone_Tasks/` on all supported versions.
 
 > **⚙️ Customization:** Customize the scripts as needed to match your specific directory structures or cloud service configurations
 
@@ -155,7 +157,7 @@ For more information on muOS and its features, visit:
 - [ ] Copied rclone binary to `MUOS/tools/rclone` (or use pre-installed `/opt/muos/bin/rclone`)
 - [ ] Copied your rclone.conf (from Step 1) to `MUOS/tools/rclone.conf`
 - [ ] Copied PNG files from `copy_to_tools_directory/` to `MUOS/tools/`
-- [ ] Copied shell scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/`
+- [ ] Copied shell scripts from `copy_to_tasks_directory/backup/` to `/opt/muos/share/task/Rclone_Tasks/` via SSH
 - [ ] Set executable permissions (Unix systems)
 - [ ] Tested cloud upload/download tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ shellcheck copy_to_tasks_directory/Cloud_Upload_Saves.sh
 ### Testing Scripts
 ```bash
 # Test script execution (dry run mode if supported)
-# Note: Full testing requires muOS environment with rclone installed
+# Note: Full testing requires muOS environment; rclone is pre-installed on MustardOS at /opt/muos/bin/rclone
 # Use verbose mode to see detailed output
 bash -x copy_to_tasks_directory/Cloud_Upload_Saves.sh --dry-run 2>&1 | head -50
 
@@ -94,7 +94,7 @@ file copy_to_tools_directory/*.png
 ### Code Organization
 
 #### Directory Structure
-- `copy_to_tasks_directory/backup/`: Cloud backup scripts (Goose-compatible)
+- `copy_to_tasks_directory/backup/`: Cloud backup scripts (MustardOS-compatible)
 - `copy_to_tools_directory/`: Binary tools and icons
 - `rclone_sample_conf_*/`: Sample configurations
 - Root: Documentation and project files
@@ -156,7 +156,7 @@ file copy_to_tools_directory/*.png
 
 #### Required Tools
 - bash (POSIX compliant shell)
-- rclone (ARMv7 binary for muOS)
+- rclone (ARMv7 binary for muOS — pre-installed on MustardOS at `/opt/muos/bin/rclone`)
 - Standard Unix tools: grep, sed, cp, mkdir
 
 #### Development Tools
@@ -167,13 +167,14 @@ file copy_to_tools_directory/*.png
 ### muOS-Specific Considerations
 
 #### Version Compatibility
-- Target muOS Goose release only
+- Target MustardOS 2601.1 (Funky Jacaranda) release only
 - Tasks live under /opt/muos/share/task
 
 #### Path Conventions
 - Use absolute paths for muOS directories
-- MUOS_ROOT="/mnt/mmc/MUOS"
-- MUOS_USER_DATA="/run/muos/storage"
+- Use GET_VAR "device" "storage/rom/mount" to dynamically resolve MUOS_ROOT
+- Use ${MUOS_STORE_DIR} (set by func.sh) for user data paths
+- Never hardcode /mnt/mmc/MUOS — it may differ by device/storage config
 - Follow muOS directory structure conventions
 
 #### Task Integration

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 📥 muOS Cloud Sync for Retro Handheld Devices
 
-*A cloud drive backup solution for save files and screenshots on muOS Retro Handheld Devices*
+*A cloud drive backup solution for save files and screenshots on muOS (MustardOS) Retro Handheld Devices*
 
 ---
 
 ## 🎮 Overview
 
-This project provides a complete cloud synchronization solution for **muOS retro handheld devices** running the **Goose release**. It allows you to automatically backup and restore your precious save files and screenshots to popular cloud storage services.
+This project provides a complete cloud synchronization solution for **muOS (MustardOS) retro handheld devices** running the **Funky Jacaranda (2601.1)** release. It allows you to automatically backup and restore your precious save files and screenshots to popular cloud storage services.
 
 ### ✨ Key Features
 
@@ -26,7 +26,7 @@ This project is adapted from the excellent work by **hotcereal** for the Miyoo M
 
 ## 🌐 Cloud Service Compatibility
 
-- ✅ **Dropbox** - Fully tested and working
+- ✅ **Dropbox** - Fully tested and working (MustardOS 2601.1 Funky Jacaranda)
 - 🔧 **Google Drive** - Should work (configuration included)
 - 🔧 **OneDrive** - Should work (configuration included)
 - 🔧 **Other rclone-supported services** - May work with proper configuration
@@ -60,7 +60,7 @@ Both upload and download operations use **intelligent timestamp-based comparison
 > **🎨 Icon Note:** The included PNG files in `copy_to_tools_directory/` are provided for users who wish to embed custom icons into their Theme installation files. These icons are not installed automatically; if you want to use them, you must manually add them to your muOS theme according to your theme's installation instructions.
 
 > **📁 Repository Structure:** This repository is organized with separate directories:
-> - `copy_to_tasks_directory/backup/` - Shell scripts for muOS Goose
+> - `copy_to_tasks_directory/backup/` - Shell scripts for MustardOS (Funky Jacaranda)
 > - `copy_to_tools_directory/` - Contains PNG icons, where you'll also place your rclone binary and config
 > - Sample configuration files for different cloud services are included for reference
 
@@ -71,7 +71,7 @@ Both upload and download operations use **intelligent timestamp-based comparison
 
 ## 📋 Requirements
 
-- muOS (Goose release)
+- MustardOS 2601.1 (Funky Jacaranda) — rclone is pre-installed at `/opt/muos/bin/rclone`
 - Desktop computer for initial setup
 - SD card reader
 - Internet connection on your handheld device
@@ -94,8 +94,7 @@ Follow these step-by-step guides to set up cloud sync. **Complete them in order:
 **[⚙️ muOS Cloud Sync Setup Guide](./2-Setup-muOS-Cloud-Sync.md)**
 
 *Do this after completing Step 1:*
-- Download ARMv7 rclone binary for your handheld device
-- Transfer files to your muOS SD card
+- Transfer files to your MustardOS SD card (rclone is pre-installed on Funky Jacaranda)
 - Install and configure the cloud sync tasks
 - Test the new Tasks in your muOS menu
 

--- a/copy_to_tasks_directory/backup/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_download_saves.sh
@@ -12,9 +12,7 @@ TEE_PID=""
 
 start_logging() {
     : > "${LOGFILE}"
-    if [ -p "${LOGPIPE}" ]; then
-        rm -f "${LOGPIPE}"
-    fi
+    if [ -p "${LOGPIPE}" ]; then rm -f "${LOGPIPE}"; fi
     if mkfifo "${LOGPIPE}"; then
         tee -a "${LOGFILE}" < "${LOGPIPE}" &
         TEE_PID=$!
@@ -24,23 +22,13 @@ start_logging() {
     fi
 }
 
-# muOS Goose OS directory paths
-MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
-MUOS_USER_DATA="${MUOS_STORE_DIR}"
-
-# Tool and config paths — prefer pre-installed rclone, fall back to tools/
+MUOS_ROOT="/mnt/mmc/MUOS"
+MUOS_USER_DATA="/run/muos/storage"
 RCLONE_BINARY="/opt/muos/bin/rclone"
 [ ! -x "${RCLONE_BINARY}" ] && RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
-
-# Target directories (where we're downloading to)
 SAVE_DIR="${MUOS_USER_DATA}/save"
 SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
-
-# Cloud storage remote and paths
-CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-
-# Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
 _BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
 CLOUD_SAVE_PATH="/${_BOARD}/saves"
 CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
@@ -49,106 +37,73 @@ cleanup() {
     sync
     echo "All Done!"
     TBOX sleep 2
-    if [ -n "${TEE_PID}" ]; then
-        kill "${TEE_PID}" >/dev/null 2>&1
-        wait "${TEE_PID}" >/dev/null 2>&1
-    fi
-    if [ -n "${LOGPIPE}" ] && [ -p "${LOGPIPE}" ]; then
-        rm -f "${LOGPIPE}"
-    fi
+    [ -n "${TEE_PID}" ] && kill "${TEE_PID}" >/dev/null 2>&1 && wait "${TEE_PID}" >/dev/null 2>&1
+    [ -p "${LOGPIPE}" ] && rm -f "${LOGPIPE}"
     FRONTEND start task
 }
-
-fail() {
-    echo "❌ ERROR: $1" >&2
-    cleanup
-    exit 1
-}
+fail() { echo "ERROR: $1" >&2; cleanup; exit 1; }
 
 start_logging
+echo "Cloud download started at $(date +"%Y-%m-%d %H:%M:%S")"
 
-echo "Starting cloud download at $(date +"%Y-%m-%d %H:%M:%S")"
+[ ! -f "${RCLONE_BINARY}" ] && fail "rclone binary not found: ${RCLONE_BINARY}"
+[ ! -x "${RCLONE_BINARY}" ] && fail "rclone binary not executable"
+[ ! -f "${RCLONE_CONFIG}" ] && fail "rclone config not found: ${RCLONE_CONFIG}"
+[ ! -d "${SAVE_DIR}" ]       && fail "Save directory not found: ${SAVE_DIR}"
+[ ! -d "${SCREENSHOT_DIR}" ] && fail "Screenshot directory not found: ${SCREENSHOT_DIR}"
 
-# (Goose OS: icon installation handled by task system)
-
-# Check for rclone binary
-if [ ! -f "${RCLONE_BINARY}" ]; then
-    echo "   rclone should be pre-installed at /opt/muos/bin/rclone on MuOS 2025+"
-    fail "rclone binary not found at ${RCLONE_BINARY}"
-fi
-
-# Check if rclone binary is executable
-if [ ! -x "${RCLONE_BINARY}" ]; then
-    fail "rclone binary is not executable (run: chmod +x ${RCLONE_BINARY})"
-fi
-
-# Check for rclone config file
-if [ ! -f "${RCLONE_CONFIG}" ]; then
-    echo "   Please copy your rclone.conf file from your computer to this location"
-    fail "rclone config file not found at ${RCLONE_CONFIG}"
-fi
-
-# Auto-detect cloud remote from config file
-echo "🔍 Detecting cloud service from config..."
+echo "Detecting cloud service..."
 CLOUD_REMOTE_NAME=$(grep -E '^\[(onedrive|gdrive|dropbox)\]' "${RCLONE_CONFIG}" | head -n 1 | sed 's/\[\(.*\)\]/\1/')
-if [ -z "${CLOUD_REMOTE_NAME}" ]; then
-    fail "No supported cloud remote found in rclone config"
-fi
-echo "   Found cloud remote: ${CLOUD_REMOTE_NAME}"
+[ -z "${CLOUD_REMOTE_NAME}" ] && fail "No cloud remote found in rclone config"
+echo "   Remote: ${CLOUD_REMOTE_NAME}"
 
-# Check target directories exist
-if [ ! -d "${SAVE_DIR}" ]; then
-    fail "Save directory not found at ${SAVE_DIR}"
-fi
-
-if [ ! -d "${SCREENSHOT_DIR}" ]; then
-    fail "Screenshot directory not found at ${SCREENSHOT_DIR}"
-fi
-
-# Test internet connectivity
-echo "🌐 Testing internet connectivity..."
-if ! ${RCLONE_BINARY} version > /dev/null 2>&1; then
-    fail "rclone command failed - check installation"
-fi
-
-# Test cloud service connectivity
-echo "☁️  Testing cloud service connectivity..."
-if ! ${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1; then
-    fail "Cannot connect to cloud service (${CLOUD_REMOTE_NAME})"
-fi
-
-echo "✅ All checks passed! Starting download..."
-
-## TODO: fix how to display the info panel in muOS
-# Display an info panel
-#LD_PRELOAD=/run/muos/storage/lib/libpadsp.so /run/muos/storage/bin/infoPanel -t "Downloading Saves" -m "Your saves are being downloaded from Dropbox!" --auto &
-
-# Synchronize saves (only download files that are newer on cloud than local)
-echo "📥 Downloading save files (newer cloud files only)..."
-echo "   📝 Note: Only files newer than local versions will be downloaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" --config="${RCLONE_CONFIG}"
-if [ $? -ne 0 ]; then
-    fail "Download of save files failed"
-fi
-
-# Synchronize screenshots (only download files that are newer on cloud than local)
-echo "📸 Downloading screenshots (newer cloud files only)..."
-echo "   📝 Note: Only files newer than local versions will be downloaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" "${SCREENSHOT_DIR}/" --config="${RCLONE_CONFIG}"
-if [ $? -ne 0 ]; then
-    fail "Download of screenshots failed"
-fi
+echo "Testing connectivity..."
+${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1 \
+    || fail "Cannot reach cloud service"
 
 echo ""
-echo "✅ Download completed successfully!"
-echo "   🛡️  Data protection: Only downloaded files that were newer than existing local versions"
-echo "   📅 Timestamp-based sync prevents accidental overwrites"
+echo "Downloading save files..."
+echo "   Excluded: legacy dirs, media files, app data, macOS junk, temp files"
+echo "   Included: all emulator battery saves (.srm .sav .dsv .rtc .mpk etc), state files, Dreamcast VMU (.bin)"
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    --exclude "saves/**" \
+    --exclude "screenshot/**" \
+    --exclude "podcaster/**" \
+    --exclude "pico8/**" \
+    --exclude "*.mp3" \
+    --exclude "*.MP3" \
+    --exclude "*.m4a" \
+    --exclude "*.M4A" \
+    --exclude "*.aac" \
+    --exclude "*.ogg" \
+    --exclude "*.flac" \
+    --exclude "*.wav" \
+    --exclude "*.mp4" \
+    --exclude "*.MP4" \
+    --exclude "*.mkv" \
+    --exclude "*.MKV" \
+    --exclude "*.avi" \
+    --exclude "*.AVI" \
+    --exclude "*.mov" \
+    --exclude "*.MOV" \
+    --exclude "*.db" \
+    --exclude "*.old" \
+    --exclude "*.bak" \
+    --exclude "*.tmp" \
+    --exclude ".DS_Store" \
+    --exclude "._*" \
+    --exclude ".Spotlight-V100" \
+    --exclude ".fseventsd" \
+    "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" \
+    --config="${RCLONE_CONFIG}" || fail "Save download failed"
 
-echo "Sync Filesystem"
+echo "Downloading screenshots..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" "${SCREENSHOT_DIR}/" \
+    --config="${RCLONE_CONFIG}" || fail "Screenshot download failed"
+
+echo ""
+echo "Download complete at $(date +"%Y-%m-%d %H:%M:%S")"
 sync
-
-echo "Download completed at $(date +"%Y-%m-%d %H:%M:%S")"
 cleanup
 exit 0
-
-

--- a/copy_to_tasks_directory/backup/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_download_saves.sh
@@ -28,8 +28,9 @@ start_logging() {
 MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
 MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
-# Tool and config paths
+# Tool and config paths — prefer pre-installed rclone, fall back to tools/
 RCLONE_BINARY="/opt/muos/bin/rclone"
+[ ! -x "${RCLONE_BINARY}" ] && RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 
 # Target directories (where we're downloading to)
@@ -72,7 +73,7 @@ echo "Starting cloud download at $(date +"%Y-%m-%d %H:%M:%S")"
 
 # Check for rclone binary
 if [ ! -f "${RCLONE_BINARY}" ]; then
-    echo "   Please follow the setup guide to download and install the ARMv7 rclone binary"
+    echo "   rclone should be pre-installed at /opt/muos/bin/rclone on MuOS 2025+"
     fail "rclone binary not found at ${RCLONE_BINARY}"
 fi
 

--- a/copy_to_tasks_directory/backup/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_download_saves.sh
@@ -38,8 +38,11 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 
 # Cloud storage remote and paths
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-CLOUD_SAVE_PATH="/ambernic/saves"
-CLOUD_SCREENSHOT_PATH="/ambernic/screenshot"
+
+# Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
+_BOARD="$(GET_VAR "device" "board/name" 2>/dev/null)"
+CLOUD_SAVE_PATH="/${_BOARD}/saves"
+CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 
 cleanup() {
     sync

--- a/copy_to_tasks_directory/backup/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_download_saves.sh
@@ -40,7 +40,7 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
 
 # Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
-_BOARD="$(GET_VAR "device" "board/name" 2>/dev/null)"
+_BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
 CLOUD_SAVE_PATH="/${_BOARD}/saves"
 CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 

--- a/copy_to_tasks_directory/backup/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_download_saves.sh
@@ -25,11 +25,11 @@ start_logging() {
 }
 
 # muOS Goose OS directory paths
-MUOS_ROOT="/mnt/mmc/MUOS"
-MUOS_USER_DATA="/run/muos/storage"
+MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
+MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
 # Tool and config paths
-RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
+RCLONE_BINARY="/opt/muos/bin/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 
 # Target directories (where we're downloading to)

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -25,11 +25,11 @@ start_logging() {
 }
 
 # muOS Goose OS directory paths
-MUOS_ROOT="/mnt/mmc/MUOS"
-MUOS_USER_DATA="/run/muos/storage"
+MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
+MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
 # Tool and config paths
-RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
+RCLONE_BINARY="/opt/muos/bin/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 # Source directories (what we're uploading)
 SAVE_DIR="${MUOS_USER_DATA}/save"
@@ -113,7 +113,7 @@ echo "✅ All checks passed! Starting upload..."
 
 ## TODO: fix how to display the info panel in muOS
 # Display an info panel
-#LD_PRELOAD=/mnt/mmc/MUOS/lib/libpadsp.so /mnt/mmc/MUOS/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
+#LD_PRELOAD=${MUOS_ROOT}/lib/libpadsp.so ${MUOS_ROOT}/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
 
 # Synchronize saves (only upload files that are newer locally than cloud)
 echo "📤 Uploading save files (newer local files only)..."

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -58,7 +58,7 @@ CLOUD_REMOTE_NAME=$(grep -E '^\[(onedrive|gdrive|dropbox)\]' "${RCLONE_CONFIG}" 
 echo "   Remote: ${CLOUD_REMOTE_NAME}"
 
 echo "Testing connectivity..."
-${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1 \
+${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" --contimeout 10s --timeout 10s --retries 1 --low-level-retries 1 > /dev/null 2>&1 \
     || fail "Cannot reach cloud service"
 
 echo ""

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -28,8 +28,9 @@ start_logging() {
 MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
 MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
-# Tool and config paths
+# Tool and config paths — prefer pre-installed rclone, fall back to tools/
 RCLONE_BINARY="/opt/muos/bin/rclone"
+[ ! -x "${RCLONE_BINARY}" ] && RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 # Source directories (what we're uploading)
 SAVE_DIR="${MUOS_USER_DATA}/save"
@@ -68,7 +69,7 @@ start_logging
 echo "Starting cloud upload at $(date +"%Y-%m-%d %H:%M:%S")"
 # Check for rclone binary
 if [ ! -f "${RCLONE_BINARY}" ]; then
-    echo "   Please follow the setup guide to download and install the ARMv7 rclone binary"
+    echo "   rclone should be pre-installed at /opt/muos/bin/rclone on MuOS 2025+"
     fail "rclone binary not found at ${RCLONE_BINARY}"
 fi
 

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -39,7 +39,7 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
 
 # Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
-_BOARD="$(GET_VAR "device" "board/name" 2>/dev/null)"
+_BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
 CLOUD_SAVE_PATH="/${_BOARD}/saves"
 CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -12,9 +12,7 @@ TEE_PID=""
 
 start_logging() {
     : > "${LOGFILE}"
-    if [ -p "${LOGPIPE}" ]; then
-        rm -f "${LOGPIPE}"
-    fi
+    if [ -p "${LOGPIPE}" ]; then rm -f "${LOGPIPE}"; fi
     if mkfifo "${LOGPIPE}"; then
         tee -a "${LOGFILE}" < "${LOGPIPE}" &
         TEE_PID=$!
@@ -24,22 +22,13 @@ start_logging() {
     fi
 }
 
-# muOS Goose OS directory paths
-MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
-MUOS_USER_DATA="${MUOS_STORE_DIR}"
-
-# Tool and config paths — prefer pre-installed rclone, fall back to tools/
+MUOS_ROOT="/mnt/mmc/MUOS"
+MUOS_USER_DATA="/run/muos/storage"
 RCLONE_BINARY="/opt/muos/bin/rclone"
 [ ! -x "${RCLONE_BINARY}" ] && RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
-# Source directories (what we're uploading)
 SAVE_DIR="${MUOS_USER_DATA}/save"
 SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
-
-# Cloud storage remote and paths
-CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-
-# Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
 _BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
 CLOUD_SAVE_PATH="/${_BOARD}/saves"
 CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
@@ -48,101 +37,73 @@ cleanup() {
     sync
     echo "All Done!"
     TBOX sleep 2
-    if [ -n "${TEE_PID}" ]; then
-        kill "${TEE_PID}" >/dev/null 2>&1
-        wait "${TEE_PID}" >/dev/null 2>&1
-    fi
-    if [ -n "${LOGPIPE}" ] && [ -p "${LOGPIPE}" ]; then
-        rm -f "${LOGPIPE}"
-    fi
+    [ -n "${TEE_PID}" ] && kill "${TEE_PID}" >/dev/null 2>&1 && wait "${TEE_PID}" >/dev/null 2>&1
+    [ -p "${LOGPIPE}" ] && rm -f "${LOGPIPE}"
     FRONTEND start task
 }
-
-fail() {
-    echo "❌ ERROR: $1" >&2
-    cleanup
-    exit 1
-}
+fail() { echo "ERROR: $1" >&2; cleanup; exit 1; }
 
 start_logging
+echo "Cloud upload started at $(date +"%Y-%m-%d %H:%M:%S")"
 
-echo "Starting cloud upload at $(date +"%Y-%m-%d %H:%M:%S")"
-# Check for rclone binary
-if [ ! -f "${RCLONE_BINARY}" ]; then
-    echo "   rclone should be pre-installed at /opt/muos/bin/rclone on MuOS 2025+"
-    fail "rclone binary not found at ${RCLONE_BINARY}"
-fi
+[ ! -f "${RCLONE_BINARY}" ] && fail "rclone binary not found: ${RCLONE_BINARY}"
+[ ! -x "${RCLONE_BINARY}" ] && fail "rclone binary not executable"
+[ ! -f "${RCLONE_CONFIG}" ] && fail "rclone config not found: ${RCLONE_CONFIG}"
+[ ! -d "${SAVE_DIR}" ]       && fail "Save directory not found: ${SAVE_DIR}"
+[ ! -d "${SCREENSHOT_DIR}" ] && fail "Screenshot directory not found: ${SCREENSHOT_DIR}"
 
-# Check if rclone binary is executable
-if [ ! -x "${RCLONE_BINARY}" ]; then
-    fail "rclone binary is not executable (run: chmod +x ${RCLONE_BINARY})"
-fi
-
-# Check for rclone config file
-if [ ! -f "${RCLONE_CONFIG}" ]; then
-    echo "   Please copy your rclone.conf file from your computer to this location"
-    fail "rclone config file not found at ${RCLONE_CONFIG}"
-fi
-
-# Auto-detect cloud remote from config file
-echo "🔍 Detecting cloud service from config..."
+echo "Detecting cloud service..."
 CLOUD_REMOTE_NAME=$(grep -E '^\[(onedrive|gdrive|dropbox)\]' "${RCLONE_CONFIG}" | head -n 1 | sed 's/\[\(.*\)\]/\1/')
-if [ -z "${CLOUD_REMOTE_NAME}" ]; then
-    fail "No supported cloud remote found in rclone config"
-fi
-echo "   Found cloud remote: ${CLOUD_REMOTE_NAME}"
+[ -z "${CLOUD_REMOTE_NAME}" ] && fail "No cloud remote found in rclone config"
+echo "   Remote: ${CLOUD_REMOTE_NAME}"
 
-# Check source directories exist
-if [ ! -d "${SAVE_DIR}" ]; then
-    fail "Save directory not found at ${SAVE_DIR}"
-fi
-
-if [ ! -d "${SCREENSHOT_DIR}" ]; then
-    fail "Screenshot directory not found at ${SCREENSHOT_DIR}"
-fi
-
-# Test internet connectivity
-echo "🌐 Testing internet connectivity..."
-if ! ${RCLONE_BINARY} version > /dev/null 2>&1; then
-    fail "rclone command failed - check installation"
-fi
-
-# Test cloud service connectivity
-echo "☁️  Testing cloud service connectivity..."
-if ! ${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1; then
-    fail "Cannot connect to cloud service (${CLOUD_REMOTE_NAME})"
-fi
-
-echo "✅ All checks passed! Starting upload..."
-
-## TODO: fix how to display the info panel in muOS
-# Display an info panel
-#LD_PRELOAD=${MUOS_ROOT}/lib/libpadsp.so ${MUOS_ROOT}/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
-
-# Synchronize saves (only upload files that are newer locally than cloud)
-echo "📤 Uploading save files (newer local files only)..."
-echo "   📝 Note: Only files newer than cloud versions will be uploaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" --config="${RCLONE_CONFIG}"
-if [ $? -ne 0 ]; then
-    fail "Upload of save files failed"
-fi
-
-# Synchronize screenshots (only upload files that are newer locally than cloud)
-echo "📸 Uploading screenshots (newer local files only)..."
-echo "   📝 Note: Only files newer than cloud versions will be uploaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${SCREENSHOT_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" --config="${RCLONE_CONFIG}"
-if [ $? -ne 0 ]; then
-    fail "Upload of screenshots failed"
-fi
+echo "Testing connectivity..."
+${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1 \
+    || fail "Cannot reach cloud service"
 
 echo ""
-echo "✅ Upload completed successfully!"
-echo "   🛡️  Data protection: Only uploaded files that were newer than existing cloud versions"
-echo "   📅 Timestamp-based sync prevents accidental overwrites"
+echo "Uploading save files..."
+echo "   Excluded: legacy dirs, media files, app data, macOS junk, temp files"
+echo "   Included: all emulator battery saves (.srm .sav .dsv .rtc .mpk etc), state files, Dreamcast VMU (.bin)"
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    --exclude "saves/**" \
+    --exclude "screenshot/**" \
+    --exclude "podcaster/**" \
+    --exclude "pico8/**" \
+    --exclude "*.mp3" \
+    --exclude "*.MP3" \
+    --exclude "*.m4a" \
+    --exclude "*.M4A" \
+    --exclude "*.aac" \
+    --exclude "*.ogg" \
+    --exclude "*.flac" \
+    --exclude "*.wav" \
+    --exclude "*.mp4" \
+    --exclude "*.MP4" \
+    --exclude "*.mkv" \
+    --exclude "*.MKV" \
+    --exclude "*.avi" \
+    --exclude "*.AVI" \
+    --exclude "*.mov" \
+    --exclude "*.MOV" \
+    --exclude "*.db" \
+    --exclude "*.old" \
+    --exclude "*.bak" \
+    --exclude "*.tmp" \
+    --exclude ".DS_Store" \
+    --exclude "._*" \
+    --exclude ".Spotlight-V100" \
+    --exclude ".fseventsd" \
+    "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" \
+    --config="${RCLONE_CONFIG}" || fail "Save upload failed"
 
-echo "Sync Filesystem"
+echo "Uploading screenshots..."
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    "${SCREENSHOT_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SCREENSHOT_PATH}/" \
+    --config="${RCLONE_CONFIG}" || fail "Screenshot upload failed"
+
+echo ""
+echo "Upload complete at $(date +"%Y-%m-%d %H:%M:%S")"
 sync
-
-echo "Upload completed at $(date +"%Y-%m-%d %H:%M:%S")"
 cleanup
 exit 0

--- a/copy_to_tasks_directory/backup/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/backup/cloud_upload_saves.sh
@@ -37,8 +37,11 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 
 # Cloud storage remote and paths
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-CLOUD_SAVE_PATH="/ambernic/saves"
-CLOUD_SCREENSHOT_PATH="/ambernic/screenshot"
+
+# Cloud folder: uses board name (e.g. rg40xx-h, tui-brick) — each device gets its own folder
+_BOARD="$(GET_VAR "device" "board/name" 2>/dev/null)"
+CLOUD_SAVE_PATH="/${_BOARD}/saves"
+CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 
 cleanup() {
     sync

--- a/copy_to_tasks_directory/pixie/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/pixie/cloud_download_saves.sh
@@ -33,8 +33,9 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 
 # Cloud storage remote and paths
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-CLOUD_SAVE_PATH="/ambernic/saves"
-CLOUD_SCREENSHOT_PATH="/ambernic/screenshot"
+_BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
+CLOUD_SAVE_PATH="/${_BOARD}/saves"
+CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 
 ##################################################################################
 # Pre-flight checks
@@ -132,7 +133,36 @@ echo ""
 # Synchronize saves (only download files that are newer on cloud than local)
 echo "📥 Downloading save files (newer cloud files only)..."
 echo "   📝 Note: Only files newer than local versions will be downloaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" --config="${RCLONE_CONFIG}"
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    --exclude "saves/**" \
+    --exclude "screenshot/**" \
+    --exclude "podcaster/**" \
+    --exclude "pico8/**" \
+    --exclude "*.mp3" \
+    --exclude "*.MP3" \
+    --exclude "*.m4a" \
+    --exclude "*.M4A" \
+    --exclude "*.aac" \
+    --exclude "*.ogg" \
+    --exclude "*.flac" \
+    --exclude "*.wav" \
+    --exclude "*.mp4" \
+    --exclude "*.MP4" \
+    --exclude "*.mkv" \
+    --exclude "*.MKV" \
+    --exclude "*.avi" \
+    --exclude "*.AVI" \
+    --exclude "*.mov" \
+    --exclude "*.MOV" \
+    --exclude "*.db" \
+    --exclude "*.old" \
+    --exclude "*.bak" \
+    --exclude "*.tmp" \
+    --exclude ".DS_Store" \
+    --exclude "._*" \
+    --exclude ".Spotlight-V100" \
+    --exclude ".fseventsd" \
+    "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" "${SAVE_DIR}/" --config="${RCLONE_CONFIG}"
 
 # Synchronize screenshots (only download files that are newer on cloud than local)
 echo "📸 Downloading screenshots (newer cloud files only)..."

--- a/copy_to_tasks_directory/pixie/cloud_download_saves.sh
+++ b/copy_to_tasks_directory/pixie/cloud_download_saves.sh
@@ -17,11 +17,11 @@ echo "$0 $*"
 ##################################################################################
 
 # muOS Goose OS directory paths
-MUOS_ROOT="/mnt/mmc/MUOS"
-MUOS_USER_DATA="/run/muos/storage"
+MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
+MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
 # Tool and config paths
-RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
+RCLONE_BINARY="/opt/muos/bin/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 
 # Task icon path (Goose OS)

--- a/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
@@ -107,7 +107,7 @@ fi
 
 # Test cloud service connectivity
 echo "☁️  Testing cloud service connectivity..."
-if ! ${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" > /dev/null 2>&1; then
+if ! ${RCLONE_BINARY} lsd ${CLOUD_REMOTE_NAME}: --config="${RCLONE_CONFIG}" --contimeout 10s --timeout 10s --retries 1 --low-level-retries 1 > /dev/null 2>&1; then
     echo "❌ ERROR: Cannot connect to cloud service (${CLOUD_REMOTE_NAME})"
     echo "   Check your internet connection and rclone configuration"
     echo "   Make sure your device is connected to WiFi"

--- a/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
@@ -33,8 +33,9 @@ SCREENSHOT_DIR="${MUOS_USER_DATA}/screenshot"
 
 # Cloud storage remote and paths
 CLOUD_REMOTE_NAME=""  # Will be auto-detected from config
-CLOUD_SAVE_PATH="/ambernic/saves"
-CLOUD_SCREENSHOT_PATH="/ambernic/screenshot"
+_BOARD="$(cat /opt/muos/device/config/board/name 2>/dev/null)"
+CLOUD_SAVE_PATH="/${_BOARD}/saves"
+CLOUD_SCREENSHOT_PATH="/${_BOARD}/screenshot"
 
 ##################################################################################
 # Pre-flight checks
@@ -132,7 +133,36 @@ echo ""
 # Synchronize saves (only upload files that are newer locally than cloud)
 echo "📤 Uploading save files (newer local files only)..."
 echo "   📝 Note: Only files newer than cloud versions will be uploaded"
-${RCLONE_BINARY} copy -P -L --no-check-certificate --update "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" --config="${RCLONE_CONFIG}"
+${RCLONE_BINARY} copy -P -L --no-check-certificate --update \
+    --exclude "saves/**" \
+    --exclude "screenshot/**" \
+    --exclude "podcaster/**" \
+    --exclude "pico8/**" \
+    --exclude "*.mp3" \
+    --exclude "*.MP3" \
+    --exclude "*.m4a" \
+    --exclude "*.M4A" \
+    --exclude "*.aac" \
+    --exclude "*.ogg" \
+    --exclude "*.flac" \
+    --exclude "*.wav" \
+    --exclude "*.mp4" \
+    --exclude "*.MP4" \
+    --exclude "*.mkv" \
+    --exclude "*.MKV" \
+    --exclude "*.avi" \
+    --exclude "*.AVI" \
+    --exclude "*.mov" \
+    --exclude "*.MOV" \
+    --exclude "*.db" \
+    --exclude "*.old" \
+    --exclude "*.bak" \
+    --exclude "*.tmp" \
+    --exclude ".DS_Store" \
+    --exclude "._*" \
+    --exclude ".Spotlight-V100" \
+    --exclude ".fseventsd" \
+    "${SAVE_DIR}/" "${CLOUD_REMOTE_NAME}:${CLOUD_SAVE_PATH}/" --config="${RCLONE_CONFIG}"
 
 # Synchronize screenshots (only upload files that are newer locally than cloud)
 echo "📸 Uploading screenshots (newer local files only)..."

--- a/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
+++ b/copy_to_tasks_directory/pixie/cloud_upload_saves.sh
@@ -17,11 +17,11 @@ echo "$0 $*"
 ##################################################################################
 
 # muOS Goose OS directory paths
-MUOS_ROOT="/mnt/mmc/MUOS"
-MUOS_USER_DATA="/run/muos/storage"
+MUOS_ROOT="$(GET_VAR "device" "storage/rom/mount")/MUOS"
+MUOS_USER_DATA="${MUOS_STORE_DIR}"
 
 # Tool and config paths
-RCLONE_BINARY="${MUOS_ROOT}/tools/rclone"
+RCLONE_BINARY="/opt/muos/bin/rclone"
 RCLONE_CONFIG="${MUOS_ROOT}/tools/rclone.conf"
 
 # Task icon path (Goose OS)
@@ -127,7 +127,7 @@ echo ""
 
 ## TODO: fix how to display the info panel in muOS
 # Display an info panel 
-#LD_PRELOAD=/mnt/mmc/MUOS/lib/libpadsp.so /mnt/mmc/MUOS/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
+#LD_PRELOAD=${MUOS_ROOT}/lib/libpadsp.so ${MUOS_ROOT}/bin/infoPanel -t "Uploading Saves" -m "Your saves are being uploaded to Cloud Drive!" --auto &
 
 # Synchronize saves (only upload files that are newer locally than cloud)
 echo "📤 Uploading save files (newer local files only)..."


### PR DESCRIPTION
## Summary
- Use `GET_VAR` and `${MUOS_STORE_DIR}` for dynamic path resolution instead of hardcoded `/mnt/mmc/MUOS`
- Update scripts to use pre-installed rclone at `/opt/muos/bin/rclone` (MustardOS 2601.1 ships with rclone)
- Update all documentation from "Goose" to "MustardOS" and target 2601.1 Funky Jacaranda
- Tested and working on Anbernic RG40XX with Dropbox

## Changes
- **Scripts**: Dynamic storage path resolution, rclone binary path updated
- **Docs**: Version references, rclone pre-install notes, path conventions updated
- **AGENTS.md**: Path conventions and version target updated